### PR TITLE
Fix tag concatenation bug in add_tags function

### DIFF
--- a/src/things_mcp/tools.py
+++ b/src/things_mcp/tools.py
@@ -781,7 +781,7 @@ class ThingsTools:
             
             for tag in valid_tags:
                 escaped_tag = self._escape_applescript_string(tag).strip('"')
-                script += f'\n    set tag names of targetTodo to tag names of targetTodo & "{escaped_tag}"'
+                script += f'\n    set tag names of targetTodo to (tag names of targetTodo) & {{"{escaped_tag}"}}'
             
             script += '''
                 return "tags_added"


### PR DESCRIPTION
## Bug Fix

Fixes a critical bug in the `add_tags` function that caused tag names to be concatenated together instead of being stored as separate tags.

## Problem

When adding tags to a todo that already had existing tags, the tags would be concatenated into a single malformed tag name (e.g., "WorkHomeEva" instead of separate "Work", "Home", "Eva" tags).

**Root Cause:** Line 784 in `tools.py` was using AppleScript string concatenation instead of list append:

```applescript
# Before (buggy):
set tag names of targetTodo to tag names of targetTodo & "Eva"
```

When AppleScript concatenates a list with a string, it coerces the list to a string first, resulting in concatenated tag names.

## Solution

Changed to proper list append syntax:

```applescript
# After (fixed):
set tag names of targetTodo to (tag names of targetTodo) & {"Eva"}
```

The curly braces `{"Eva"}` create a list, and list concatenation properly appends the new tag to the existing tag list.

## Impact

- **Severity**: High - Created 45 malformed concatenated tags in production use
- **Affected Function**: `add_tags()` in `tools.py`
- **When Triggered**: When adding tags to todos that already had tags
- **Side Effect**: Created malformed tags like "WorkHomeEvaColinAnnaLuka"

## Testing

- ✅ Verified AppleScript syntax creates proper list
- ✅ Confirmed fix with direct AppleScript execution
- ✅ Deleted 41 empty malformed tags from production

## Files Changed

- `src/things_mcp/tools.py` (1 line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)