### PR TITLE
fix: remove blocking AppleScript probe from server startup

### DIFF
--- a/src/things_mcp/main.py
+++ b/src/things_mcp/main.py
@@ -50,28 +50,14 @@ class ServerManager:
                 logging.getLogger().setLevel(logging.DEBUG)
                 logger.debug("Debug logging enabled")
             
-            # Check if Things 3 is available
-            applescript_manager = AppleScriptManager(timeout=timeout, retry_count=retry_count)
-            
-            # Note: is_things_running() is async, but we're in a sync context
-            # For startup checks, we'll create a simple sync version
-            import subprocess
-            try:
-                result = subprocess.run(
-                    ["osascript", "-e", 'tell application "Things3" to return true'],
-                    capture_output=True,
-                    timeout=5,
-                    text=True
-                )
-                if result.returncode == 0:
-                    logger.info("Things 3 detected and accessible")
-                else:
-                    logger.warning("Things 3 is not running or not accessible")
-                    logger.info("Please ensure Things 3 is installed and running")
-            except (subprocess.TimeoutExpired, Exception) as e:
-                logger.warning(f"Could not check Things 3 status: {e}")
-                logger.info("Continuing anyway - Things 3 might start later")
-            
+            # Note: Things 3 availability is checked lazily on the first tool call
+            # via AppleScriptManager (async, with timeout + retries). We intentionally
+            # do NOT probe Things 3 here: a synchronous `osascript` call at startup
+            # blocks the MCP stdio handshake and can trigger a macOS Automation (TCC)
+            # consent dialog, which stalls long enough for the client to mark the
+            # server as "failed to connect". It also auto-launches Things 3 unnecessarily.
+            # Use `--health-check` or `--test-applescript` for explicit connectivity checks.
+
             # Mark as running
             self.running = True
             


### PR DESCRIPTION
## Problem

The MCP server intermittently failed to connect. The cause was a synchronous AppleScript probe in `ServerManager.start()` that ran **before** the MCP stdio loop started:

```python
subprocess.run(["osascript", "-e", 'tell application "Things3" to return true'], timeout=5)
```

This probe **gated nothing** — it only logged `info`/`warning` and continued regardless of the result. But at startup it was actively harmful:

- Blocked the MCP handshake for up to 5s on every launch.
- `tell application "Things3"` **auto-launches Things 3** if it's closed.
- The first time the server binary sends Apple events, macOS shows a **TCC Automation consent dialog**. While that dialog is pending, `osascript` blocks → the client's init timeout elapses → **"failed to connect."**

## Fix

Remove the startup probe. Things 3 availability is already checked **lazily on the first tool call** via `AppleScriptManager` (async, with timeout + retries). Explicit connectivity checks remain available via `--health-check` and `--test-applescript`.

## Testing

- `pytest tests/unit` → 596 passed. (Pre-existing unrelated failures in an uncommitted in-progress `test_bulk_tag_functionality.py` referencing an unimplemented `bulk_add_tags`.)
- No tests exercised the removed startup probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)