### PR TITLE
chore: harden release process (test gate, PyPI verify, single version source)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,39 @@
-name: Publish to PyPI
+name: CI / Publish to PyPI
 
 on:
+  push:
+    branches: [main]
+  pull_request:
   release:
     types: [published]
   workflow_dispatch:
 
+# Mitigate the Node.js 20 action-runtime deprecation (forced to Node 24 from 2026-06-16).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
+  # Test gate: must pass before anything is built or published.
+  test:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install package with dev dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+
+    - name: Run unit tests
+      run: pytest tests/unit
+
   build:
+    needs: test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -36,6 +63,8 @@ jobs:
         path: dist/
 
   publish-to-pypi:
+    # Only publish on a published GitHub Release. On pushes/PRs we still run test + build.
+    if: github.event_name == 'release'
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -52,3 +81,39 @@ jobs:
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+
+  # Post-publish verification: fail loudly if the version never appears on PyPI.
+  # This is the guard that would have caught v1.4.4 silently never publishing.
+  verify-pypi:
+    if: github.event_name == 'release'
+    needs: publish-to-pypi
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Determine version from built wheel
+      id: ver
+      run: |
+        VERSION=$(ls dist/*.whl | sed -E 's/.*mcp_server_things-([0-9]+\.[0-9]+\.[0-9]+[^-]*)-.*/\1/')
+        echo "version=$VERSION" | tee -a "$GITHUB_OUTPUT"
+
+    - name: Wait for version to appear on PyPI
+      run: |
+        VERSION="${{ steps.ver.outputs.version }}"
+        URL="https://pypi.org/pypi/mcp-server-things/${VERSION}/json"
+        echo "Verifying $URL"
+        for attempt in $(seq 1 12); do
+          code=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+          if [ "$code" = "200" ]; then
+            echo "✓ mcp-server-things ${VERSION} is live on PyPI"
+            exit 0
+          fi
+          echo "Attempt ${attempt}/12: PyPI returned HTTP ${code}; retrying in 15s..."
+          sleep 15
+        done
+        echo "::error::mcp-server-things ${VERSION} did not appear on PyPI after publish"
+        exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -679,92 +679,83 @@ today = get_today(mode='standard', limit=20)
 
 ## Release Process
 
-When creating a new release, follow these steps to ensure version consistency across all files:
+Publishing is **automated by CI**. Creating a GitHub Release triggers
+`.github/workflows/publish.yml`, which runs the test gate, builds the package,
+publishes to PyPI via trusted publishing, and then **verifies** the version is
+live on PyPI (failing loudly if it isn't). Do not run `twine upload` manually
+unless trusted publishing is broken (see break-glass below).
 
-### 1. Update Version Numbers
+### 1. Bump the version (single source of truth)
 
-**Critical Files (MUST update):**
+The version lives in **one** place — `src/things_mcp/__init__.py`. `pyproject.toml`
+reads it dynamically (`[tool.setuptools.dynamic] version = {attr = "things_mcp.__version__"}`),
+and `server.py` / `--version` import the same `__version__`.
 
 ```bash
-# 1. Update package version
-# File: pyproject.toml (line 7)
-version = "X.Y.Z"
-
-# 2. Update runtime version
-# File: src/things_mcp/__init__.py (line 3)
+# File: src/things_mcp/__init__.py
 __version__ = "X.Y.Z"
+```
 
-# 3. Update CHANGELOG
-# File: CHANGELOG.md (top of file)
+Then add the matching section to `CHANGELOG.md` (top of file):
+
+```markdown
 ## [X.Y.Z] - YYYY-MM-DD
 
 ### Fixed
 - Bug fix description
-
-### Added
-- New feature description
-
-### Changed
-- Change description
 ```
 
-### 2. Commit and Tag
+### 2. Commit and tag
 
 ```bash
-# Run tests first
-pytest
-
-# Commit changes
-git add pyproject.toml src/things_mcp/__init__.py CHANGELOG.md
+pytest tests/unit                       # gate also runs in CI
+git add src/things_mcp/__init__.py CHANGELOG.md
 git commit -m "Release vX.Y.Z - Brief description"
-
-# Push to GitHub
 git push origin main
 
-# Create and push tag
 git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-### 3. Create GitHub Release
+### 3. Create the GitHub Release (this publishes to PyPI)
 
 ```bash
-# Create release with notes from CHANGELOG
 gh release create vX.Y.Z \
   --title "vX.Y.Z - Release Title" \
   --notes "$(sed -n '/## \[X.Y.Z\]/,/## \[/p' CHANGELOG.md | head -n -1)"
 ```
 
-### 4. Publish to PyPI
+CI then runs `test → build → publish-to-pypi → verify-pypi`. Watch it:
 
 ```bash
-# Build distribution packages
-python -m build
-
-# Upload to PyPI
-python -m twine upload dist/mcp_server_things-X.Y.Z*
+gh run watch "$(gh run list --workflow=publish.yml --limit 1 --json databaseId --jq '.[0].databaseId')" --exit-status
 ```
 
-### Version Consistency Notes
+If `publish-to-pypi` fails with `403 ... OIDC scoped token is not valid for
+project`, a trusted publisher for this repo+workflow is registered on the wrong
+PyPI project. Fix it under the `mcp-server-things` project's Publishing settings
+(repo `ebowman/mcp-server-things`, workflow `publish.yml`, environment `pypi`)
+and remove any stray publisher on other projects, then re-run the workflow.
 
-- **pyproject.toml** - Package version for pip/PyPI
-- **src/things_mcp/__init__.py** - Runtime version (used by server.py)
-- **CHANGELOG.md** - Version history with dates
-- Version is automatically synced: `__version__` is imported by server.py and reported via `get_server_capabilities()`
-- No need to update version in documentation examples (README.md, CONTRIBUTING.md) - those are placeholders
+### Break-glass: manual upload
+
+Only if CI publishing is broken and the release must ship:
+
+```bash
+python -m build
+python -m twine check dist/mcp_server_things-X.Y.Z*
+python -m twine upload dist/mcp_server_things-X.Y.Z*   # uses ~/.pypirc token
+```
 
 ### Release Checklist
 
-- [ ] All tests pass (`pytest`)
-- [ ] Version updated in `pyproject.toml`
-- [ ] Version updated in `src/things_mcp/__init__.py`
+- [ ] Version bumped in `src/things_mcp/__init__.py` (only here)
 - [ ] CHANGELOG.md updated with date and changes
-- [ ] Committed with descriptive message
-- [ ] Pushed to GitHub
-- [ ] Git tag created and pushed
-- [ ] GitHub release created
-- [ ] Published to PyPI
-- [ ] Verify version reporting: AI should report correct version when queried
+- [ ] `pytest tests/unit` passes
+- [ ] Committed, pushed to `main`, tag pushed
+- [ ] GitHub Release created
+- [ ] CI `publish.yml` green through `verify-pypi` (confirms PyPI is live)
+- [ ] AI reports the correct version when queried (`--version` / `get_server_capabilities`)
 
 ## Code Quality Improvements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-server-things"
-version = "1.4.5"
+dynamic = ["version"]
 description = "Model Context Protocol server for Things 3 task management integration"
 readme = "README.md"
 authors = [
-    {name = "MCP Developer", email = "developer@example.com"}
+    {name = "Eric Bowman", email = "ebowman@boboco.ie"}
 ]
 keywords = ["mcp", "things3", "applescript", "task-management", "productivity"]
 classifiers = [
@@ -74,6 +74,10 @@ docs = [
 
 [project.scripts]
 things-mcp = "src.things_mcp.__main__:main"
+
+[tool.setuptools.dynamic]
+# Single source of truth for the version: src/things_mcp/__init__.py
+version = {attr = "things_mcp.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/tests/unit/test_edge_cases.py
+++ b/tests/unit/test_edge_cases.py
@@ -573,8 +573,9 @@ class TestStatusValues:
     @pytest.mark.asyncio
     async def test_retrieve_completed_todos(self, tools_with_mock):
         """Test retrieving completed todos from logbook."""
-        with patch('things_mcp.tools_helpers.read_operations.things.logbook') as mock_logbook:
-            mock_logbook.return_value = [{
+        # get_logbook is backed by things.todos(status='completed'), filtered by stop_date.
+        with patch('things_mcp.tools_helpers.read_operations.things.todos') as mock_todos:
+            mock_todos.return_value = [{
                 "uuid": "todo-1",
                 "title": "Completed task",
                 "status": "completed",

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -58,19 +58,16 @@ class TestGetTodos:
     @pytest.mark.asyncio
     async def test_get_todos_all(self, tools_with_mock):
         """Test getting all todos."""
-        # Mock operation queue to avoid timeout
-        with patch('things_mcp.tools.get_operation_queue') as mock_get_queue:
-            mock_queue = AsyncMock()
-            mock_queue.enqueue = AsyncMock(return_value="op-id")
-            mock_queue.wait_for_operation = AsyncMock(return_value=[{
-                "id": "todo-123",
-                "name": "Sample Todo",
-                "status": "open"
-            }])
-            mock_get_queue.return_value = mock_queue
-            
+        # get_todos() reads via things.todos(status='incomplete'), not the queue.
+        with patch('things_mcp.tools_helpers.read_operations.things.todos') as mock_todos:
+            mock_todos.return_value = [{
+                "uuid": "todo-123",
+                "title": "Sample Todo",
+                "status": "incomplete"
+            }]
+
             result = await tools_with_mock.get_todos()
-            
+
             assert isinstance(result, list)
             assert len(result) > 0
     


### PR DESCRIPTION
Follow-up to #11. Addresses the release-process weaknesses exposed while shipping v1.4.5 (CI publishing had been silently broken since v1.4.4, which never reached PyPI).

## Changes

1. **Test gate** — `publish.yml` now runs `pytest tests/unit` on macOS, and `build`/`publish` depend on it. Tests also run on `push`/`pull_request`, so the gate is exercised before any release (previously nothing ran tests in CI).
2. **Post-publish verification** — new `verify-pypi` job polls PyPI for the released version and fails loudly if it never appears. This is the guard that would have caught v1.4.4 silently never publishing.
3. **Single source of version truth** — `pyproject.toml` now derives the version dynamically from `things_mcp.__version__` (`setuptools` `dynamic` + `attr`). Releases bump only `src/things_mcp/__init__.py`.
4. **One authoritative release path** — `CLAUDE.md` documents CI as the way releases publish; manual `twine upload` is now explicitly break-glass only.
5. **Housekeeping** — fix placeholder author metadata; mitigate the GitHub Actions Node 20 runtime deprecation.

Also fixes a stale unit test (`test_retrieve_completed_todos` patched `things.logbook`, but `get_logbook` calls `things.todos(status='completed')`), so the gate is green.

## Publish flow after this PR

`test → build → publish-to-pypi (release only) → verify-pypi (release only)`

Publishing only happens on a published GitHub Release; pushes/PRs stop at `test → build`.

> Note: this does **not** fix the PyPI-side trusted-publisher misconfiguration (`403 OIDC scoped token is not valid for project`) — that's an account-side change. Once corrected, this workflow publishes and verifies automatically.

## Testing

- `pytest tests/unit` → 597 passed locally.
- Local `python -m build` confirms the dynamic version resolves to the value in `__init__.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)